### PR TITLE
Do not allow snippets of type method or field before a class statement

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2023 Red Hat Inc. and others.
+* Copyright (c) 2023, 2025 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -29,20 +29,8 @@ public enum JavaCursorContextKind {
 	IN_EMPTY_FILE(1),
 
 	/**
-	 * The cursor is before a type declaration body, either at the root of a file or
-	 * within another class. The cursor is before any annotations on the type.
-	 *
-	 * eg.
-	 * <code>
-	 * <br />
-	 * package org.acme;<br />
-	 * <br />
-	 * |<br />
-	 * &commat;Inject<br />
-	 * public class MyClass {<br />
-	 * <br />
-	 * }<br />
-	 * </code>
+	 * The cursor is before a type declaration body within another class.
+	 * The cursor is before any annotations on the type.
 	 *
 	 * eg.
 	 * <code>
@@ -61,7 +49,7 @@ public enum JavaCursorContextKind {
 	 * }<br />
 	 * </code>
 	 */
-	BEFORE_CLASS(2),
+	BEFORE_INNER_CLASS(2),
 
 	/**
 	 * The cursor is in a type declaration body, and the next declaration in the
@@ -194,6 +182,25 @@ public enum JavaCursorContextKind {
 	 * </code>
 	 */
 	IN_CLASS(8),
+
+
+	/**
+	 * The cursor is before a type declaration body at the root of a file.
+	 * The cursor is before any annotations on the type.
+	 *
+	 * eg.
+	 * <code>
+	 * <br />
+	 * package org.acme;<br />
+	 * <br />
+	 * |<br />
+	 * &commat;Inject<br />
+	 * public class MyClass {<br />
+	 * <br />
+	 * }<br />
+	 * </code>
+	 */
+	BEFORE_TOP_LEVEL_CLASS(9),
 
 	/**
 	 * None of the above context apply.

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManagerForJava.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManagerForJava.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 Red Hat Inc. and others.
+* Copyright (c) 2019, 2025 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -466,7 +466,7 @@ public class PropertiesManagerForJava {
 				if (visitor.isInAnnotations()) {
 					return JavaCursorContextKind.IN_CLASS_ANNOTATIONS;
 				}
-				return JavaCursorContextKind.BEFORE_CLASS;
+				return JavaCursorContextKind.BEFORE_TOP_LEVEL_CLASS;
 			}
 			default:
 				return JavaCursorContextKind.NONE;
@@ -482,7 +482,7 @@ public class PropertiesManagerForJava {
 		case ASTNode.ENUM_DECLARATION:
 		case ASTNode.RECORD_DECLARATION:
 			return visitor.isInAnnotations() ? JavaCursorContextKind.IN_CLASS_ANNOTATIONS
-					: JavaCursorContextKind.BEFORE_CLASS;
+					: JavaCursorContextKind.BEFORE_INNER_CLASS;
 		case ASTNode.ANNOTATION_TYPE_MEMBER_DECLARATION:
 		case ASTNode.METHOD_DECLARATION:
 			return visitor.isInAnnotations() ? JavaCursorContextKind.IN_METHOD_ANNOTATIONS

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/snippets/JavaFileCursorContextTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/snippets/JavaFileCursorContextTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2023 Red Hat Inc. and others.
+* Copyright (c) 2023, 2025 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -319,7 +319,7 @@ public class JavaFileCursorContextTest extends BasePropertiesManagerTest {
 		// static class MyNestedNestedClass {
 		// ...
 		MicroProfileJavaCompletionParams params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(4, 0));
-		assertEquals(JavaCursorContextKind.BEFORE_CLASS,
+		assertEquals(JavaCursorContextKind.BEFORE_INNER_CLASS,
 				PropertiesManagerForJava.getInstance().javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
 
 		// ...
@@ -330,7 +330,7 @@ public class JavaFileCursorContextTest extends BasePropertiesManagerTest {
 		// static class MyNestedNestedClass {
 		// ...
 		params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(5, 0));
-		assertEquals(JavaCursorContextKind.BEFORE_CLASS,
+		assertEquals(JavaCursorContextKind.BEFORE_INNER_CLASS,
 				PropertiesManagerForJava.getInstance().javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
 
 		// ...
@@ -350,7 +350,7 @@ public class JavaFileCursorContextTest extends BasePropertiesManagerTest {
 		// public class MyNestedClass {
 		// ...
 		params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(1, 0));
-		assertEquals(JavaCursorContextKind.BEFORE_CLASS,
+		assertEquals(JavaCursorContextKind.BEFORE_TOP_LEVEL_CLASS,
 				PropertiesManagerForJava.getInstance().javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
 
 		// ...

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2023 Red Hat Inc. and others.
+* Copyright (c) 2023, 2025 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -29,20 +29,8 @@ public enum JavaCursorContextKind {
 	IN_EMPTY_FILE(1),
 
 	/**
-	 * The cursor is before a type declaration body, either at the root of a file or
-	 * within another class. The cursor is before any annotations on the type.
-	 *
-	 * eg.
-	 * <code>
-	 * <br />
-	 * package org.acme;<br />
-	 * <br />
-	 * |<br />
-	 * &commat;Inject<br />
-	 * public class MyClass {<br />
-	 * <br />
-	 * }<br />
-	 * </code>
+	 * The cursor is before a type declaration body within another class.
+	 * The cursor is before any annotations on the type.
 	 *
 	 * eg.
 	 * <code>
@@ -61,7 +49,7 @@ public enum JavaCursorContextKind {
 	 * }<br />
 	 * </code>
 	 */
-	BEFORE_CLASS(2),
+	BEFORE_INNER_CLASS(2),
 
 	/**
 	 * The cursor is in a type declaration body, and the next declaration in the
@@ -194,6 +182,24 @@ public enum JavaCursorContextKind {
 	 * </code>
 	 */
 	IN_CLASS(8),
+
+	/**
+	 * The cursor is before a type declaration body at the root of a file.
+	 * The cursor is before any annotations on the type.
+	 *
+	 * eg.
+	 * <code>
+	 * <br />
+	 * package org.acme;<br />
+	 * <br />
+	 * |<br />
+	 * &commat;Inject<br />
+	 * public class MyClass {<br />
+	 * <br />
+	 * }<br />
+	 * </code>
+	 */
+	BEFORE_TOP_LEVEL_CLASS(9),
 
 	/**
 	 * None of the above context apply.

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/snippets/SnippetContextForJava.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/snippets/SnippetContextForJava.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020 Red Hat Inc. and others.
+* Copyright (c) 2020, 2025 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -98,10 +98,10 @@ public class SnippetContextForJava implements ISnippetContext<JavaSnippetComplet
 			return kind == JavaCursorContextKind.IN_EMPTY_FILE;
 		case METHOD:
 			return kind == JavaCursorContextKind.BEFORE_FIELD || kind == JavaCursorContextKind.BEFORE_METHOD
-					|| kind == JavaCursorContextKind.BEFORE_CLASS || kind == JavaCursorContextKind.IN_CLASS;
+					|| kind == JavaCursorContextKind.BEFORE_INNER_CLASS || kind == JavaCursorContextKind.IN_CLASS;
 		case FIELD:
 			return kind == JavaCursorContextKind.BEFORE_FIELD || kind == JavaCursorContextKind.BEFORE_METHOD
-					|| kind == JavaCursorContextKind.BEFORE_CLASS || kind == JavaCursorContextKind.IN_CLASS;
+					|| kind == JavaCursorContextKind.BEFORE_INNER_CLASS || kind == JavaCursorContextKind.IN_CLASS;
 		default:
 			return false;
 		}


### PR DESCRIPTION
The issue is that `rest_get` and `mpirc` snippets are provided as suggestions when the user's cursor is between the `package` statement and the `class` statement. This is incorrect and it is easy for a person to stumble across.

This fix helps with this problem but it means these two snippets do not appear when the cursor is just before an `enum` or an inner class statement. This seems like an improvement. 

Is this change acceptable?

Fixes #402