### PR TITLE
Skip making a fake project if only sources are being scanned

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManager.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManager.java
@@ -316,6 +316,9 @@ public class PropertiesManager {
 	 */
 	private IJavaProject getJavaProject(IJavaProject javaProject, boolean excludeTestCode,
 			List<MicroProfilePropertiesScope> scopes, SubMonitor monitor) throws JavaModelException {
+		if (scopes.indexOf(MicroProfilePropertiesScope.dependencies) == -1) {
+			return javaProject;
+		}
 		if (javaProject instanceof FakeJavaProject) {
 			// The java project is already resolved
 			return javaProject;


### PR DESCRIPTION
This change provides a modest performance improvement, since the fake Java project is only needed to scan the dependencies.