### PR TITLE
Add GitHub Action -based CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,29 @@
+name: Tests
+on: [push, pull_request]
+jobs:
+  microprofile-jdt-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Set up Eclipse Temurin JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - name: Build and test lsp4mp JDT component
+        working-directory: microprofile.jdt
+        run: ./mvnw -B -U clean verify
+  microprofile-ls-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Set up Eclipse Temurin JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - name: Build and test lsp4mp language server component
+        working-directory: microprofile.ls/org.eclipse.lsp4mp.ls
+        run: ./mvnw -B -U clean verify


### PR DESCRIPTION
There are two goals for this PR:
- I think that the root cause of the test timeout on Jenkins is that not enough RAM is available to the Jenkins agents
- We can run the microprofile.jdt and microprofile.ls test suites in parallel and report their results separately
  - In the existing Jenkins suite, if the microprofile.jdt test suite fails, we don't run the microprofile.ls suite, which is bad because the microprofile.jdt almost always fails, so we never know the results of the microprofile.ls suite

Fixes #495