### PR TITLE
Addresses fix #520: JavaCursorContextKind IllegalArgumentException in lsp4mp

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
@@ -231,11 +231,11 @@ public enum JavaCursorContextKind {
 		return value;
 	}
 
-	public static JavaCursorContextKind forValue(int value) {
-		JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
-		if (value < 1 || value > allValues.length)
+    public static JavaCursorContextKind forValue(int value) {
+        JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
+        if (value < 1 || value > allValues.length)
             throw new IllegalArgumentException("Illegal enum value: " + value);
         return allValues[value - 1];
-	}
+    }
 
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
@@ -233,7 +233,12 @@ public enum JavaCursorContextKind {
 
 	public static JavaCursorContextKind forValue(int value) {
 		JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
-		if (value < 1 || value > allValues.length)
+		
+		// Root cause and fix for JavaCursorContextKind IllegalArgumentException issue #520 when value passed is 2000
+        if (value == NONE.getValue()) {
+            return NONE;
+        }
+        if (value < 1 || value > allValues.length - 1)
 			throw new IllegalArgumentException("Illegal enum value: " + value);
 		return allValues[value - 1];
 	}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
@@ -231,11 +231,11 @@ public enum JavaCursorContextKind {
 		return value;
 	}
 
-    public static JavaCursorContextKind forValue(int value) {
-        JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
-        if (value < 1 || value > allValues.length)
-            throw new IllegalArgumentException("Illegal enum value: " + value);
-        return allValues[value - 1];
-    }
+	public static JavaCursorContextKind forValue(int value) {
+		JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
+		if (value < 1 || value > allValues.length)
+			throw new IllegalArgumentException("Illegal enum value: " + value);
+		return allValues[value - 1];
+	}
 
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
@@ -219,7 +219,7 @@ public enum JavaCursorContextKind {
 	 * }<br />
 	 * </code>
 	 */
-	NONE(2000);
+	NONE(10);
 
 	private final int value;
 
@@ -233,12 +233,7 @@ public enum JavaCursorContextKind {
 
 	public static JavaCursorContextKind forValue(int value) {
 		JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
-		
-        // Root cause and fix for JavaCursorContextKind IllegalArgumentException issue #520 when value passed is 2000
-        if (value == NONE.getValue()) {
-            return NONE;
-        }
-        if (value < 1 || value > allValues.length - 1)
+		if (value < 1 || value > allValues.length)
             throw new IllegalArgumentException("Illegal enum value: " + value);
         return allValues[value - 1];
 	}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
@@ -234,13 +234,13 @@ public enum JavaCursorContextKind {
 	public static JavaCursorContextKind forValue(int value) {
 		JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
 		
-		// Root cause and fix for JavaCursorContextKind IllegalArgumentException issue #520 when value passed is 2000
+        // Root cause and fix for JavaCursorContextKind IllegalArgumentException issue #520 when value passed is 2000
         if (value == NONE.getValue()) {
             return NONE;
         }
         if (value < 1 || value > allValues.length - 1)
-			throw new IllegalArgumentException("Illegal enum value: " + value);
-		return allValues[value - 1];
+            throw new IllegalArgumentException("Illegal enum value: " + value);
+        return allValues[value - 1];
 	}
 
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
@@ -230,11 +230,11 @@ public enum JavaCursorContextKind {
 		return value;
 	}
 
-	public static JavaCursorContextKind forValue(int value) {
-		JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
+    public static JavaCursorContextKind forValue(int value) {
+        JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
         if (value < 1 || value > allValues.length)
             throw new IllegalArgumentException("Illegal enum value: " + value);
         return allValues[value - 1];
-	}
+    }
 
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
@@ -218,7 +218,7 @@ public enum JavaCursorContextKind {
 	 * }<br />
 	 * </code>
 	 */
-	NONE(2000);
+	NONE(10);
 
 	private final int value;
 
@@ -232,12 +232,7 @@ public enum JavaCursorContextKind {
 
 	public static JavaCursorContextKind forValue(int value) {
 		JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
-		
-        // Root cause and fix for JavaCursorContextKind IllegalArgumentException issue #520 when value passed is 2000
-        if (value == NONE.getValue()) {
-            return NONE;
-        }
-        if (value < 1 || value > allValues.length - 1)
+        if (value < 1 || value > allValues.length)
             throw new IllegalArgumentException("Illegal enum value: " + value);
         return allValues[value - 1];
 	}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
@@ -232,7 +232,12 @@ public enum JavaCursorContextKind {
 
 	public static JavaCursorContextKind forValue(int value) {
 		JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
-		if (value < 1 || value > allValues.length)
+		
+        // Root cause and fix for JavaCursorContextKind IllegalArgumentException issue #520 when value passed is 2000
+        if (value == NONE.getValue()) {
+            return NONE;
+        }
+        if (value < 1 || value > allValues.length - 1)
 			throw new IllegalArgumentException("Illegal enum value: " + value);
 		return allValues[value - 1];
 	}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
@@ -238,8 +238,8 @@ public enum JavaCursorContextKind {
             return NONE;
         }
         if (value < 1 || value > allValues.length - 1)
-			throw new IllegalArgumentException("Illegal enum value: " + value);
-		return allValues[value - 1];
+            throw new IllegalArgumentException("Illegal enum value: " + value);
+        return allValues[value - 1];
 	}
 
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
@@ -230,11 +230,11 @@ public enum JavaCursorContextKind {
 		return value;
 	}
 
-    public static JavaCursorContextKind forValue(int value) {
-        JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
-        if (value < 1 || value > allValues.length)
-            throw new IllegalArgumentException("Illegal enum value: " + value);
-        return allValues[value - 1];
-    }
+	public static JavaCursorContextKind forValue(int value) {
+		JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
+		if (value < 1 || value > allValues.length)
+			throw new IllegalArgumentException("Illegal enum value: " + value);
+		return allValues[value - 1];
+	}
 
 }


### PR DESCRIPTION
The PR addresses Issue: https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/520
Root causes were observed in JavaCursorContextKind.java files in

* lsp4jakarta.ls
* lsp4jakarta.jdt